### PR TITLE
Allow .m4a playback

### DIFF
--- a/player.js
+++ b/player.js
@@ -37,6 +37,7 @@ function extToMime(ext){
 	ext=ext.toLowerCase();
 	log('File Extension:',ext);
 	switch(ext){
+		case "m4a":return "audio/mpeg";
 		case "mp3":return "audio/mpeg";
 		case "ogg":return "audio/ogg";
 		case "oga":return "audio/ogg";


### PR DESCRIPTION
For me, in both Vivaldi and Waterfox, .m4a files weren't supported. This fixes it.